### PR TITLE
Add new notification reasons

### DIFF
--- a/lexicons/com/nnabeyang/soyokaze/notification/defs.json
+++ b/lexicons/com/nnabeyang/soyokaze/notification/defs.json
@@ -17,7 +17,10 @@
             "quote",
             "starterpack-joined",
             "verified",
-            "unverified"
+            "unverified",
+            "like-via-repost",
+            "repost-via-repost",
+            "subscribed-post"
           ]
         },
         "uri": { "type": "string", "format": "at-uri" },


### PR DESCRIPTION
Add three new notification reasons to the lexicon: `like-via-repost`, `repost-via-repost`, and `subscribed-post`.